### PR TITLE
V2.6.79

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Cookbook Engineering Team'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Provides docker_service, docker_image, and docker_container resources'
-version '2.6.7'
+version '2.6.79'
 
 source_url 'https://github.com/chef-cookbooks/docker'
 issues_url 'https://github.com/chef-cookbooks/docker/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ version '2.6.7'
 source_url 'https://github.com/chef-cookbooks/docker'
 issues_url 'https://github.com/chef-cookbooks/docker/issues'
 
-depends 'compat_resource', '>= 12.9.0'
+depends 'compat_resource', '= 12.7.3'
 
 supports 'amazon'
 supports 'centos'


### PR DESCRIPTION
### Description

Locks down compat_resource cookbook to 12.7.3 so it doesn't cause chef-client run to loop forever
